### PR TITLE
Only install tomli on Python <3.11

### DIFF
--- a/lsp-multiplexer.py
+++ b/lsp-multiplexer.py
@@ -2,13 +2,16 @@ import asyncio
 import json
 import sys
 import argparse
-import tomli
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple, Union, Any, Set
 from urllib.parse import urlparse
 import traceback
 import logging
 import os
+if sys.version_info >= (3, 11):
+    import tomllib
+else:
+    import tomli as tomllib
 
 @dataclass
 class ServerConfig:
@@ -40,8 +43,8 @@ def load_config(config_file: str) -> List[ServerConfig]:
     """Load server configurations from a TOML file"""
     try:
         with open(config_file, 'rb') as f:
-            config = tomli.load(f)
         
+            config = tomllib.load(f)
         servers_config = config.get('servers', [])
         if not servers_config:
             raise ValueError("No servers defined in config file")
@@ -49,7 +52,7 @@ def load_config(config_file: str) -> List[ServerConfig]:
         return [ServerConfig.from_config(server) for server in servers_config]
     except FileNotFoundError:
         raise FileNotFoundError(f"Config file not found: {config_file}")
-    except tomli.TOMLDecodeError as e:
+    except tomllib.TOMLDecodeError as e:
         raise ValueError(f"Invalid TOML in config file: {e}")
 
 def get_default_config_paths() -> List[str]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 description = "Simple LSP server multiplexer"
 readme = "README.md"
 requires-python = ">=3.8"
-dependencies = ["tomli"]
+dependencies = ["tomli; python_version < \"3.11\""]


### PR DESCRIPTION
Python 3.11+ has tomllib in the standard library